### PR TITLE
Place nwg-menu.lock in XDG_RUNTIME_DIR if it exists

### DIFF
--- a/main.go
+++ b/main.go
@@ -154,7 +154,11 @@ func main() {
 	}()
 
 	// We want the same key/mouse binding to turn the dock off: kill the running instance and exit.
-	lockFilePath := fmt.Sprintf("%s/nwg-menu.lock", tempDir())
+	lockFileDir := runtimeDir()
+	if lockFileDir == "" {
+		lockFileDir = tempDir()
+	}
+	lockFilePath := fmt.Sprintf("%s/nwg-menu.lock", lockFileDir)
 	lockFile, err := singleinstance.CreateLockFile(lockFilePath)
 	if err != nil {
 		pid, err := readTextFile(lockFilePath)

--- a/tools.go
+++ b/tools.go
@@ -161,6 +161,10 @@ func cacheDir() string {
 	return ""
 }
 
+func runtimeDir() string {
+	return os.Getenv("XDG_RUNTIME_DIR")
+}
+
 func tempDir() string {
 	if os.Getenv("TMPDIR") != "" {
 		return os.Getenv("TMPDIR")


### PR DESCRIPTION
This allows multiple users on the same system to use nwg-menu.
